### PR TITLE
Force the webview to be the screen size

### DIFF
--- a/aerogear-android-authz/src/main/res/layout/oauth_web_view.xml
+++ b/aerogear-android-authz/src/main/res/layout/oauth_web_view.xml
@@ -15,6 +15,6 @@
     <WebView
         android:id="@+id/web_oauth"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent" />
 
 </LinearLayout>


### PR DESCRIPTION
This PR force the webview to be the screen size and prevent this kind of problems

|  |  |
| :-: | :-: |
| ![screenshot_2014-12-22-18-42-18](https://cloud.githubusercontent.com/assets/13337/5531156/9fc32fde-8a0f-11e4-9cb5-38f1a1c34e75.png) | ![screenshot_2014-12-22-18-42-26](https://cloud.githubusercontent.com/assets/13337/5531157/9fc398e8-8a0f-11e4-8531-0edc3879065c.png) |

It also fix the https://github.com/aerogear/aerogear-android-cookbook/pull/26 problems when you use Facebook
