### PR TITLE
Agdroid 319

### DIFF
--- a/aerogear-android-authz-test/pom.xml
+++ b/aerogear-android-authz-test/pom.xml
@@ -45,6 +45,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-authz</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>

--- a/aerogear-android-authz-test/src/main/java/org/jboss/aerogear/android/authorization/test/oauth2/IntentOAuth2AuthzModuleTest.java
+++ b/aerogear-android-authz-test/src/main/java/org/jboss/aerogear/android/authorization/test/oauth2/IntentOAuth2AuthzModuleTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.android.authorization.test.oauth2;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.jboss.aerogear.android.authorization.AuthorizationManager;
+import org.jboss.aerogear.android.authorization.AuthzModule;
+import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthorizationConfiguration;
+import org.jboss.aerogear.android.authorization.oauth2.intent.OAuth2IntentAuthzModule;
+import org.jboss.aerogear.android.authorization.test.MainActivity;
+import org.jboss.aerogear.android.authorization.test.util.PatchedActivityInstrumentationTestCase;
+
+/**
+ * Tests the {@link OAuth2IntentAuthzModule} class.
+ */
+public class IntentOAuth2AuthzModuleTest extends PatchedActivityInstrumentationTestCase<MainActivity>{
+
+    private static final URL BASE_URL;
+
+    static {
+        try {
+            BASE_URL = new URL("https://example.com");
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    public IntentOAuth2AuthzModuleTest() {
+        super(MainActivity.class);
+    }
+    
+    /**
+     * If the OAuth2 Config Object has withIntent set then asModule should return
+     * a OAuth2IntentAuthzModule instance.
+     */
+    public void testWithIntentCreatesIntentModule() {
+        OAuth2AuthorizationConfiguration config = AuthorizationManager.config("name", OAuth2AuthorizationConfiguration.class);
+        config.setBaseURL(BASE_URL);
+        config.setWithIntent(true);
+
+        AuthzModule module = config.asModule();
+
+        assertTrue(module instanceof OAuth2IntentAuthzModule);
+        
+    }
+    
+}

--- a/aerogear-android-authz-test/src/main/java/org/jboss/aerogear/android/authorization/test/oauth2/OAuth2AuthzModuleTest.java
+++ b/aerogear-android-authz-test/src/main/java/org/jboss/aerogear/android/authorization/test/oauth2/OAuth2AuthzModuleTest.java
@@ -31,6 +31,7 @@ import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzService;
 import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthorizationException;
 import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzModule;
 import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzSession;
+import org.jboss.aerogear.android.authorization.oauth2.webview.OAuth2WebViewAuthzModule;
 import org.jboss.aerogear.android.authorization.test.util.PatchedActivityInstrumentationTestCase;
 import org.jboss.aerogear.android.authorization.test.util.VoidCallback;
 import org.mockito.ArgumentCaptor;
@@ -123,8 +124,8 @@ public class OAuth2AuthzModuleTest extends PatchedActivityInstrumentationTestCas
         config.setBaseURL(BASE_URL);
 
         OAuth2AuthzModule module = (OAuth2AuthzModule) config.asModule();
-        Class<?> callbackClass = Class.forName("org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzModule$OAuth2AuthorizationCallback");
-        Constructor<?> constructor = callbackClass.getDeclaredConstructor(OAuth2AuthzModule.class, Activity.class, Callback.class, ServiceConnection.class);
+        Class<?> callbackClass = Class.forName("org.jboss.aerogear.android.authorization.oauth2.webview.OAuth2WebViewAuthzModule$OAuth2AuthorizationCallback");
+        Constructor<?> constructor = callbackClass.getDeclaredConstructor(OAuth2WebViewAuthzModule.class, Activity.class, Callback.class, ServiceConnection.class);
         constructor.setAccessible(true);
 
         Callback callback = (Callback) constructor.newInstance(module, mockActivity, new VoidCallback(), mockServiceConnection);
@@ -153,8 +154,8 @@ public class OAuth2AuthzModuleTest extends PatchedActivityInstrumentationTestCas
         config.setBaseURL(BASE_URL);
 
         OAuth2AuthzModule module = (OAuth2AuthzModule) config.asModule();
-        Class<?> callbackClass = Class.forName("org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzModule$OAuth2AccessCallback");
-        Constructor<?> constructor = callbackClass.getDeclaredConstructor(OAuth2AuthzModule.class, Activity.class, Callback.class, ServiceConnection.class);
+        Class<?> callbackClass = Class.forName("org.jboss.aerogear.android.authorization.oauth2.webview.OAuth2WebViewAuthzModule$OAuth2AccessCallback");
+        Constructor<?> constructor = callbackClass.getDeclaredConstructor(OAuth2WebViewAuthzModule.class, Activity.class, Callback.class, ServiceConnection.class);
         constructor.setAccessible(true);
 
         Callback callback = (Callback) constructor.newInstance(module, mockActivity, new VoidCallback(), mockServiceConnection);
@@ -164,6 +165,6 @@ public class OAuth2AuthzModuleTest extends PatchedActivityInstrumentationTestCas
         callback.onSuccess("testToken");
 
         Mockito.verify(mockActivity, times(1)).unbindService(eq(mockServiceConnection));
-        assertEquals("testToken", MainActivity.UnitTestUtils.getPrivateField(module, "account", OAuth2AuthzSession.class).getAccessToken());
+        assertEquals("testToken", ((OAuth2AuthzSession)MainActivity.UnitTestUtils.getSuperPrivateField(module, "account")).getAccessToken());
     }
 }

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
@@ -1,18 +1,18 @@
 /**
- * JBoss, Home of Professional Open Source
- * Copyright Red Hat, Inc., and individual contributors.
+ * JBoss, Home of Professional Open Source Copyright Red Hat, Inc., and
+ * individual contributors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.jboss.aerogear.android.authorization.oauth2;
 
@@ -27,6 +27,7 @@ import java.util.Collections;
 import org.jboss.aerogear.android.core.Config;
 import org.jboss.aerogear.android.authorization.AuthzModule;
 import org.jboss.aerogear.android.authorization.AuthorizationConfiguration;
+import org.jboss.aerogear.android.authorization.oauth2.intent.OAuth2IntentAuthzModule;
 
 public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration<OAuth2AuthorizationConfiguration> implements Config<OAuth2AuthorizationConfiguration> {
 
@@ -39,13 +40,14 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     private String clientId = "";
     private String clientSecret = "";
     private String accountId = "";
+    private boolean withIntent = false;
     private final Set<Pair<String, String>> additionalAuthorizationParams = new HashSet<Pair<String, String>>();
     private final Set<Pair<String, String>> additionalAccessParams = new HashSet<Pair<String, String>>();
 
     /**
      * The authzEnpoint defines the endpoint which the Authorization module will
      * use to obtain an authorization token.
-     * 
+     *
      * @return the current authzEndpoint
      */
     public String getAuthzEndpoint() {
@@ -55,7 +57,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The authzEnpoint defines the endpoint which the Authorization module will
      * use to obtain an authorization token.
-     * 
+     *
      * @param authzEndpoint new authzEndpoint
      * @return the current configuration
      */
@@ -67,7 +69,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The redirect URL is the url which handles consuming a response from the
      * authorization server.
-     * 
+     *
      * @return the current redirectURL.
      */
     public String getRedirectURL() {
@@ -77,7 +79,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The redirect URL is the url which handles consuming a response from the
      * authorization server.
-     * 
+     *
      * @param redirectURL a new redirectURL
      * @return the current configuration.
      */
@@ -89,9 +91,9 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The accessTokenEndpoint is responsible for generating an accesstoken for
      * an authorized user.
-     * 
+     *
      * @return the current accessTokenEndpoint
-     * 
+     *
      */
     public String getAccessTokenEndpoint() {
         return accessTokenEndpoint;
@@ -100,10 +102,10 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The accessTokenEndpoint is responsible for generating an accesstoken for
      * an authorized user.
-     * 
+     *
      * @param accessTokenEndpoint a new accessTokenEndpoint
      * @return the current configuration
-     * 
+     *
      */
     public OAuth2AuthorizationConfiguration setAccessTokenEndpoint(String accessTokenEndpoint) {
         this.accessTokenEndpoint = accessTokenEndpoint;
@@ -111,10 +113,10 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * 
+     *
      * Scopes are a list of permissions the application will request at
      * Authorization.
-     * 
+     *
      * @return a copy of the current list of scopes
      */
     public List<String> getScopes() {
@@ -122,10 +124,10 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * 
+     *
      * Scopes are a list of permissions the application will request at
      * Authorization.
-     * 
+     *
      * @param scopes a new List of scopes
      * @return the current configuration
      */
@@ -137,7 +139,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The client ID is the ID assigned to the application by the service
      * provider.
-     * 
+     *
      * @return the current clientID
      */
     public String getClientId() {
@@ -147,7 +149,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * The client ID is the ID assigned to the application by the service
      * provider.
-     * 
+     *
      * @param clientId a new clientId
      * @return the current configuration
      */
@@ -158,7 +160,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
 
     /**
      * The client secret is assigned to the application by the service provider.
-     * 
+     *
      * @return the current clientSecret
      */
     public String getClientSecret() {
@@ -167,7 +169,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
 
     /**
      * The client secret is assigned to the application by the service provider.
-     * 
+     *
      * @param clientSecret a new clientSecret
      * @return the current configuration
      */
@@ -177,9 +179,10 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * The account ID parameter is to identify it ID of the {@link OAuth2AuthzSession} which will be used to store the information.
+     * The account ID parameter is to identify it ID of the
+     * {@link OAuth2AuthzSession} which will be used to store the information.
      * It is unique per app and generated by you, the developer.
-     * 
+     *
      * @return the current account
      */
     public String getAccountId() {
@@ -187,9 +190,10 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * The account ID parameter is to identify it ID of the {@link OAuth2AuthzSession} which will be used to store the information.
+     * The account ID parameter is to identify it ID of the
+     * {@link OAuth2AuthzSession} which will be used to store the information.
      * It is unique per app and generated by you, the developer.
-     * 
+     *
      * @param accountId the new account ID
      * @return the current configuration
      */
@@ -201,7 +205,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * Sometimes a implementation will need additional parameters when
      * authorization is performed.
-     * 
+     *
      * @return the current set of authorization parameters.
      */
     public Set<Pair<String, String>> getAdditionalAuthorizationParams() {
@@ -211,7 +215,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     /**
      * Sometimes a implementation will need additional parameters when
      * authorization is performed.
-     * 
+     *
      * @param additionalAuthorizationParam add a new Pair of AuthorizationParams
      * @return the current configuration
      */
@@ -232,8 +236,9 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * Sometimes a implementation will need additional parameters when access is performed.
-     * 
+     * Sometimes a implementation will need additional parameters when access is
+     * performed.
+     *
      * @return the current set of authorization parameters.
      */
     public Set<Pair<String, String>> getAdditionalAccessParams() {
@@ -241,8 +246,9 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
     }
 
     /**
-     * Sometimes a implementation will need additional parameters when access is performed.
-     * 
+     * Sometimes a implementation will need additional parameters when access is
+     * performed.
+     *
      * @param additionalAccessParam add a new Pair of AccessParams
      * @return the current configuration
      */
@@ -280,12 +286,16 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
         params.getAdditionalAccessParams().addAll(additionalAccessParams);
         params.getAdditionalAuthorizationParams().addAll(additionalAuthorizationParams);
 
-        return new OAuth2AuthzModule(params);
+        if (withIntent) {
+            return new OAuth2IntentAuthzModule(params);
+        } else {
+            return new OAuth2AuthzModule(params);
+        }
     }
 
     /**
      * The baseURL is the url which endpoints will be appended to.
-     * 
+     *
      * @return the current baseURL
      */
     public URL getBaseURL() {
@@ -294,7 +304,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
 
     /**
      * The baseURL is the url which endpoints will be appended to.
-     * 
+     *
      * @param baseURL new baseURL
      * @return the current configuration.
      */
@@ -305,9 +315,9 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
 
     /**
      * The refresh endpoint is the path to the location of the refresh token.
-     * 
+     *
      * Defaults to an empty String.
-     * 
+     *
      * @return the current baseURL
      */
     public String getRefreshEndpoint() {
@@ -316,16 +326,40 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
 
     /**
      * The refresh endpoint is the path to the location of the refresh token.
-     * 
+     *
      * Defaults to an empty String.
-     * 
+     *
      * @param refreshEndpoint a new endpoint.
-     * 
+     *
      * @return the current configuration.
      */
     public OAuth2AuthorizationConfiguration setRefreshEndpoint(String refreshEndpoint) {
         this.refreshEndpoint = refreshEndpoint;
         return this;
+    }
+
+    /**
+     * WithIntent will cause the AuthzModule to fire a BROWSE intent with the
+     * OAuth2 data packaged inside of it.
+     *
+     * Defaults to false.
+     *
+     * @return the current withIntent setting.
+     */
+    public boolean getWithIntent() {
+        return withIntent;
+    }
+
+    /**
+     * WithIntent will cause the AuthzModule to fire a BROWSE intent with the
+     * OAuth2 data packaged inside of it.
+     *
+     * Defaults to false.
+     *
+     * @param withIntent whether to use an intent or not
+     */
+    public void setWithIntent(boolean withIntent) {
+        this.withIntent = withIntent;
     }
 
 }

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
@@ -357,9 +357,11 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
      * Defaults to false.
      *
      * @param withIntent whether to use an intent or not
+     * @return the current configuration
      */
-    public void setWithIntent(boolean withIntent) {
+    public OAuth2AuthorizationConfiguration setWithIntent(boolean withIntent) {
         this.withIntent = withIntent;
+        return this;
     }
 
 }

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthorizationConfiguration.java
@@ -28,6 +28,7 @@ import org.jboss.aerogear.android.core.Config;
 import org.jboss.aerogear.android.authorization.AuthzModule;
 import org.jboss.aerogear.android.authorization.AuthorizationConfiguration;
 import org.jboss.aerogear.android.authorization.oauth2.intent.OAuth2IntentAuthzModule;
+import org.jboss.aerogear.android.authorization.oauth2.webview.OAuth2WebViewAuthzModule;
 
 public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration<OAuth2AuthorizationConfiguration> implements Config<OAuth2AuthorizationConfiguration> {
 
@@ -289,7 +290,7 @@ public class OAuth2AuthorizationConfiguration extends AuthorizationConfiguration
         if (withIntent) {
             return new OAuth2IntentAuthzModule(params);
         } else {
-            return new OAuth2AuthzModule(params);
+            return new OAuth2WebViewAuthzModule(params);
         }
     }
 

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2Utils.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2Utils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.android.authorization.oauth2;
+
+import android.net.Uri;
+import android.util.Pair;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import static org.jboss.aerogear.android.pipe.util.UrlUtils.appendToBaseURL;
+
+/**
+ * A collection of utility methods for working with OAuth2
+ *
+ */
+public final class OAuth2Utils {
+
+    private OAuth2Utils() {
+    }
+
+    public static URL buildAuthzURL(OAuth2Properties config, String state) throws UnsupportedEncodingException, MalformedURLException {
+        URL authzEndpoint = appendToBaseURL(config.getBaseURL(), config.getAuthzEndpoint());
+        Uri redirectURL = Uri.parse(config.getRedirectURL());
+        
+        ArrayList<String> scopes = new ArrayList<String>(config.getScopes());
+        String clientId = config.getClientId();
+
+        String query = "?scope=%s&redirect_uri=%s&client_id=%s&state=%s&response_type=code";
+        query = String.format(query, formatScopes(scopes),
+                URLEncoder.encode(redirectURL.toString(), "UTF-8"),
+                clientId, state);
+
+        if (config.getAdditionalAuthorizationParams() != null
+                && config.getAdditionalAuthorizationParams().size() > 0) {
+            for (Pair<String, String> param : config.getAdditionalAuthorizationParams()) {
+                query += String.format("&%s=%s", URLEncoder.encode(param.first, "UTF-8"), URLEncoder.encode(param.second, "UTF-8"));
+            }
+        }
+
+        return new URL(authzEndpoint.toString() + query);
+    }
+
+    public static String formatScopes(ArrayList<String> scopes) throws UnsupportedEncodingException {
+
+        StringBuilder scopeValue = new StringBuilder();
+        String append = "";
+        for (String scope : scopes) {
+            scopeValue.append(append);
+            scopeValue.append(URLEncoder.encode(scope, "UTF-8"));
+            append = "+";
+        }
+
+        return scopeValue.toString();
+    }
+
+}

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2WebFragmentFetchAutorization.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2WebFragmentFetchAutorization.java
@@ -18,14 +18,10 @@ package org.jboss.aerogear.android.authorization.oauth2;
 
 import android.app.Activity;
 import android.net.Uri;
-import android.util.Pair;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
 import org.jboss.aerogear.android.core.Callback;
-import static org.jboss.aerogear.android.pipe.util.UrlUtils.appendToBaseURL;
 
 /**
  * This class displays a WebView Dialog Fragment to facilitates exchanging
@@ -55,42 +51,14 @@ public class OAuth2WebFragmentFetchAutorization {
 
     }
 
-    private String formatScopes(ArrayList<String> scopes) throws UnsupportedEncodingException {
-
-        StringBuilder scopeValue = new StringBuilder();
-        String append = "";
-        for (String scope : scopes) {
-            scopeValue.append(append);
-            scopeValue.append(URLEncoder.encode(scope, "UTF-8"));
-            append = "+";
-        }
-
-        return scopeValue.toString();
-    }
-
-    private void doAuthorization(OAuth2Properties config, final Callback<String> callback) throws UnsupportedEncodingException, MalformedURLException {
+     private void doAuthorization(OAuth2Properties config, final Callback<String> callback) throws UnsupportedEncodingException, MalformedURLException {
 
         URL baseURL = config.getBaseURL();
-        URL authzEndpoint = appendToBaseURL(baseURL, config.getAuthzEndpoint());
         Uri redirectURL = Uri.parse(config.getRedirectURL());
-        ArrayList<String> scopes = new ArrayList<String>(config.getScopes());
-        String clientId = config.getClientId();
+        
+        URL authzURL = OAuth2Utils.buildAuthzURL(config, state);
 
-        String query = "?scope=%s&redirect_uri=%s&client_id=%s&state=%s&response_type=code";
-        query = String.format(query, formatScopes(scopes),
-                URLEncoder.encode(redirectURL.toString(), "UTF-8"),
-                clientId, state);
-
-        if (config.getAdditionalAuthorizationParams() != null
-                && config.getAdditionalAuthorizationParams().size() > 0) {
-            for (Pair<String, String> param : config.getAdditionalAuthorizationParams()) {
-                query += String.format("&%s=%s", URLEncoder.encode(param.first, "UTF-8"), URLEncoder.encode(param.second, "UTF-8"));
-            }
-        }
-
-        URL authURL = new URL(authzEndpoint.toString() + query);
-
-        final OAuthWebViewDialog dialog = OAuthWebViewDialog.newInstance(authURL, redirectURL);
+        final OAuthWebViewDialog dialog = OAuthWebViewDialog.newInstance(authzURL, redirectURL);
         dialog.setReceiver(new OAuthWebViewDialog.OAuthReceiver() {
             @Override
             public void receiveOAuthCode(String code) {
@@ -110,5 +78,6 @@ public class OAuth2WebFragmentFetchAutorization {
         dialog.setStyle(android.R.style.Theme_Light_NoTitleBar, 0);
         dialog.show(activity.getFragmentManager(), "TAG");
     }
+
 
 }

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/intent/OAuth2IntentAuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/intent/OAuth2IntentAuthzModule.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.android.authorization.oauth2.intent;
+
+import android.app.Activity;
+import java.net.URI;
+import org.jboss.aerogear.android.authorization.AuthzModule;
+import org.jboss.aerogear.android.authorization.oauth2.OAuth2Properties;
+import org.jboss.aerogear.android.core.Callback;
+import org.jboss.aerogear.android.pipe.http.HttpException;
+import org.jboss.aerogear.android.pipe.module.AuthorizationFields;
+import org.jboss.aerogear.android.pipe.module.ModuleFields;
+
+/**
+ * This is a generic AuthzModule which using intent processing to fetch tokens
+ * to authorize requests.
+ */
+public class OAuth2IntentAuthzModule implements AuthzModule {
+
+    public OAuth2IntentAuthzModule(OAuth2Properties params) {
+        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean isAuthorized() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean hasCredentials() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void requestAccess(Activity activity, Callback<String> callback) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean refreshAccess() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void deleteAccount() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public AuthorizationFields getAuthorizationFields(URI requestUri, String method, byte[] requestBody) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public ModuleFields loadModule(URI relativeURI, String httpMethod, byte[] requestBody) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean handleError(HttpException exception) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+}

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/intent/OAuth2IntentAuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/intent/OAuth2IntentAuthzModule.java
@@ -16,62 +16,61 @@
 package org.jboss.aerogear.android.authorization.oauth2.intent;
 
 import android.app.Activity;
-import java.net.URI;
-import org.jboss.aerogear.android.authorization.AuthzModule;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import java.util.UUID;
+import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzModule;
+import org.jboss.aerogear.android.authorization.oauth2.OAuth2AuthzService;
+import org.jboss.aerogear.android.authorization.oauth2.OAuth2FetchAccess;
 import org.jboss.aerogear.android.authorization.oauth2.OAuth2Properties;
 import org.jboss.aerogear.android.core.Callback;
-import org.jboss.aerogear.android.pipe.http.HttpException;
-import org.jboss.aerogear.android.pipe.module.AuthorizationFields;
-import org.jboss.aerogear.android.pipe.module.ModuleFields;
 
 /**
  * This is a generic AuthzModule which using intent processing to fetch tokens
  * to authorize requests.
  */
-public class OAuth2IntentAuthzModule implements AuthzModule {
+public class OAuth2IntentAuthzModule extends OAuth2AuthzModule {
 
     public OAuth2IntentAuthzModule(OAuth2Properties params) {
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        super(params);
     }
 
     @Override
-    public boolean isAuthorized() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    public void requestAccess(final Activity activity, final Callback<String> callback) {
+        final String state = UUID.randomUUID().toString();
+
+        final OAuth2AuthzService.AGAuthzServiceConnection connection = new OAuth2AuthzService.AGAuthzServiceConnection() {
+
+            @Override
+            public void onServiceConnected(ComponentName className, IBinder iBinder) {
+                super.onServiceConnected(className, iBinder);
+                doRequestAccess(state, activity, callback, this);
+            }
+
+        };
+
+        activity.bindService(new Intent(activity.getApplicationContext(), OAuth2AuthzService.class
+        ), connection, Context.BIND_AUTO_CREATE
+        );
     }
 
-    @Override
-    public boolean hasCredentials() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    private void doRequestAccess(String state, Activity activity, Callback<String> callback, OAuth2AuthzService.AGAuthzServiceConnection instance) {
+        service = instance.getService();
+
+        if (isNullOrEmpty(accountId)) {
+            throw new IllegalArgumentException("need to have accountId set");
+        }
+
+        if (!service.hasAccount(accountId)) {
+
+        } else {
+
+            OAuth2FetchAccess fetcher = new OAuth2FetchAccess(service);
+            fetcher.fetchAccessCode(accountId, config, callback);
+
+        }
     }
 
-    @Override
-    public void requestAccess(Activity activity, Callback<String> callback) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public boolean refreshAccess() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public void deleteAccount() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public AuthorizationFields getAuthorizationFields(URI requestUri, String method, byte[] requestBody) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public ModuleFields loadModule(URI relativeURI, String httpMethod, byte[] requestBody) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public boolean handleError(HttpException exception) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-    
 }

--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/webview/OAuth2WebViewAuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/webview/OAuth2WebViewAuthzModule.java
@@ -1,0 +1,182 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.android.authorization.oauth2.webview;
+
+import org.jboss.aerogear.android.authorization.oauth2.*;
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.ServiceConnection;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import java.util.UUID;
+
+import org.jboss.aerogear.android.core.Callback;
+
+/**
+ * 
+ * An Authorization module which works with the OAuth2 protocol.
+ * 
+ * Authorization is performed in a WebView and returned to the calling activity.
+ * 
+ */
+public class OAuth2WebViewAuthzModule extends OAuth2AuthzModule {
+
+    private static final IntentFilter AUTHZ_FILTER;
+
+    static {
+        AUTHZ_FILTER = new IntentFilter();
+        AUTHZ_FILTER.addAction("org.jboss.aerogear.android.authz.RECEIVE_AUTHZ");
+    }
+    
+    private final String TAG = OAuth2WebViewAuthzModule.class.getSimpleName();
+
+    public OAuth2WebViewAuthzModule(OAuth2Properties config) {
+        super(config);
+    }
+
+    @Override
+    public void requestAccess(final Activity activity, final Callback<String> callback) {
+
+        final String state = UUID.randomUUID().toString();
+
+        final OAuth2AuthzService.AGAuthzServiceConnection connection = new OAuth2AuthzService.AGAuthzServiceConnection() {
+
+            @Override
+            public void onServiceConnected(ComponentName className, IBinder iBinder) {
+                super.onServiceConnected(className, iBinder);
+                doRequestAccess(state, activity, callback, this);
+            }
+
+        };
+
+        activity.bindService(new Intent(activity.getApplicationContext(), OAuth2AuthzService.class
+                ), connection, Context.BIND_AUTO_CREATE
+                );
+
+    }
+
+
+    private void doRequestAccess(final String state, final Activity activity, final Callback<String> callback, final OAuth2AuthzService.AGAuthzServiceConnection instance) {
+
+        service = instance.getService();
+
+        if (isNullOrEmpty(accountId)) {
+            throw new IllegalArgumentException("need to have accountId set");
+        }
+
+        if (!service.hasAccount(accountId)) {
+
+            OAuth2WebFragmentFetchAutorization authzFetch = new OAuth2WebFragmentFetchAutorization(activity, state);
+            authzFetch.performAuthorization(config, new OAuth2AuthorizationCallback(activity, callback, instance));
+
+        } else {
+
+            OAuth2FetchAccess fetcher = new OAuth2FetchAccess(service);
+            fetcher.fetchAccessCode(accountId, config, new OAuth2AccessCallback(activity, callback, instance));
+
+        }
+
+    }
+
+
+    private class OAuth2AccessCallback implements Callback<String> {
+
+        private final Activity callingActivity;
+        private final Callback<String> originalCallback;
+        private final ServiceConnection serviceConnection;
+        private final Handler myHandler;
+
+        public OAuth2AccessCallback(Activity callingActivity, Callback<String> originalCallback, ServiceConnection serviceConnection) {
+            this.callingActivity = callingActivity;
+            this.originalCallback = originalCallback;
+            this.serviceConnection = serviceConnection;
+            myHandler = new Handler(Looper.myLooper());
+        }
+
+        @Override
+        public void onSuccess(final String accessToken) {
+            account = service.getAccount(accountId);
+            try {
+                callingActivity.unbindService(serviceConnection);
+            } catch (IllegalArgumentException ignore) {}
+            myHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    originalCallback.onSuccess(accessToken);
+                }
+            });
+        }
+
+        @Override
+        public void onFailure(final Exception e) {
+            myHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        callingActivity.unbindService(serviceConnection);
+                    } catch (IllegalArgumentException ignore) {}
+                    originalCallback.onFailure(e);
+                }
+            });
+        }
+    }
+
+    private class OAuth2AuthorizationCallback implements Callback<String> {
+
+        private final Activity callingActivity;
+        private final Callback<String> originalCallback;
+        private final ServiceConnection serviceConnection;
+        private final Handler myHandler;
+
+        public OAuth2AuthorizationCallback(Activity callingActivity, Callback<String> originalCallback, ServiceConnection serviceConnection) {
+            this.callingActivity = callingActivity;
+            this.originalCallback = originalCallback;
+            this.serviceConnection = serviceConnection;
+            myHandler = new Handler(Looper.myLooper());
+        }
+
+        @Override
+        public void onSuccess(final String code) {
+            OAuth2AuthzSession session = new OAuth2AuthzSession();
+            session.setAuthorizationCode(code);
+            session.setAccountId(accountId);
+            session.setClientId(clientId);
+            service.addAccount(session);
+
+            OAuth2FetchAccess fetcher = new OAuth2FetchAccess(service);
+            fetcher.fetchAccessCode(accountId, config, new OAuth2AccessCallback(callingActivity, originalCallback, serviceConnection));
+        }
+
+        @Override
+        public void onFailure(final Exception e) {
+            myHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        callingActivity.unbindService(serviceConnection);
+                    } catch (IllegalArgumentException ignore) {}
+                    originalCallback.onFailure(e);
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
This includes support for performing OAuth based authentication using web browser intents.

How To Test : 
 * make sure you have `aerogear-android-core', `aerogear-android-security', `aerogear-android-pipe', and `aerogear-android-store',  installed at 2.2.0-SNAPSHOT (ie latest from master).
 * fetch https://github.com/secondsun/aerogear-android-cookbook/tree/AGDROID-319 and configure the **Shoot and Share** demo
 * Make sure you have a keycloak instance running of the Shoot and Share server.
 ** Note if you are using KC 1.2.0 the realm.json file did not import correctly for me and I had to set the realm up manually
 * Take a picture and upload with keycloak providing the authentication
 * Profit

Todo and Notes : 
 * As per the ML post from last week, this works best if your service support custom URI schemas.  We need up update the documents for this
 * Once people have +1'd this I will merge and submit a PR for the ShootAndShare demo.