### PR TITLE
Authorization handling after errors

### DIFF
--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
@@ -141,10 +141,11 @@ public abstract class OAuth2AuthzModule implements AuthzModule {
      * refreshed or if the status wasn't of UNAUTHORIZED or FORBIDDEN.
      */
     public final boolean handleError(HttpException exception) {
+        int statusCode = exception.getStatusCode();
 
-        if (exception.getStatusCode() == HttpURLConnection.HTTP_UNAUTHORIZED
-                || exception.getStatusCode() == HttpURLConnection.HTTP_FORBIDDEN) {
-            return isAuthorized() && refreshAccess();
+        if (statusCode == HttpURLConnection.HTTP_UNAUTHORIZED
+                || statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+            return refreshAccess() && isAuthorized();
         } else {
             return false;
         }


### PR DESCRIPTION
The OG—https://issues.jboss.org/browse/AGDROID-490

Java uses short-circuit avaluation for conditional statements. I. e. such kind of statements are executed from left to right.

As a result in this particular case authorization token is not getting refreshed at all, because the first conditional (is authorized) is always false.

Also, status code caching saves some bits.