### PR TITLE
Change refresh to change current account instead of auth token.

### DIFF
--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
@@ -103,7 +103,8 @@ public abstract class OAuth2AuthzModule implements AuthzModule {
             }
 
             try {
-                account.setAccessToken(service.fetchAccessToken(accountId, config));
+                service.fetchAccessToken(accountId, config);
+                account = service.getAccount(accountId);
                 Log.d(TAG, "Access token refresh complete!");
                 return true;
             } catch (OAuth2AuthorizationException ex) {


### PR DESCRIPTION
After refresh in the previous version only the authorization token is being updated. That means that any other information, especially interesting expiration date, is not updated.

In real-world situation that means that even after refresh was happened AuthzModule.isAuthorized will return negative anyway, because expiration date is not updated and stays old, i. e. token is considered expired even if it was refreshed just fine and can be applied to requests.