### PR TITLE
OAuth2 deleteAccount now removes the account from memory

### DIFF
--- a/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
+++ b/aerogear-android-authz/src/main/java/org/jboss/aerogear/android/authorization/oauth2/OAuth2AuthzModule.java
@@ -155,6 +155,7 @@ public abstract class OAuth2AuthzModule implements AuthzModule {
     @Override
     public final void deleteAccount() {
         service.removeAccount(accountId);
+        removeAccount();
     }
 
     protected boolean isNullOrEmpty(String testString) {
@@ -168,6 +169,14 @@ public abstract class OAuth2AuthzModule implements AuthzModule {
      */
     protected void setAccount(OAuth2AuthzSession account) {
         this.account = account;
+    }
+
+    /**
+     * Removes the account used in the module.
+     *
+     */
+    protected void removeAccount() {
+        this.account = null;
     }
 
 }


### PR DESCRIPTION
Resolved the issue [AGDROID-602]. When calling OAuth2AuthzModule.deleteAccount it deleted the account from SQL datastore but in memory the this.account was still set. Now changed it to null.