### PR TITLE
Update gradle example in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add to your application's `build.gradle` file
 
 ```groovy
 dependencies {
-  compile 'org.jboss.aerogear:aerogear-android-authz:3.1.1'
+  implementation 'org.jboss.aerogear:aerogear-android-authz:4.0.0'
 }
 ```
 


### PR DESCRIPTION
## Motivation
Make developers lives easier to implement library.

## What
Updated the example gradle code to reference the latest tagged version. Also changed "compile" to "implementation"

## Why
The previous example gradle code references the buggy 3.1.1 build. "compile" is deprecated and replaced by "implementation"

## How
Simple text change

## Verification Steps
 
1. add the new gradle example code into a project to use the aerogear-android-authz library
2. Sync gradle files
3. Ensure version 4.0.0 is being used.

## Checklist:

- [ x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

 

